### PR TITLE
move truffle-contract dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "recursive-readdir": "2.1.0",
     "strip-ansi": "3.0.1",
     "style-loader": "0.13.1",
-    "truffle-contract": "^1.1.8",
     "url-loader": "0.5.7",
     "webpack": "1.14.0",
     "webpack-dev-server": "1.16.2",
@@ -58,7 +57,8 @@
     "recompose": "^0.26.0",
     "redux": "^3.6.0",
     "redux-auth-wrapper": "^1.0.0",
-    "redux-thunk": "^2.2.0"
+    "redux-thunk": "^2.2.0",
+    "truffle-contract": "^1.1.8"
   },
   "scripts": {
     "start": "node scripts/start.js",


### PR DESCRIPTION
Because common code running on frontend use this dependency, for example here:
https://github.com/NikitaKoren/ethWaterloo/blob/533336901bb7ed269e88a1a57365218760a74eac/src/campaigns/ui/contribute/ContributeFormActions.js#L4